### PR TITLE
Fix path problem from tutorial

### DIFF
--- a/tutorials/tutorial1-Loop and import.md
+++ b/tutorials/tutorial1-Loop and import.md
@@ -71,7 +71,7 @@ def loop():
 &nbsp;&nbsp;&nbsp;&nbsp;Then, you need specific the fpath of ```main.mjs``` in src/config.py:
 ```python
 # // Project Config
-# define MAIN_JS_PATH C:/Users/22290/ScreepsArena/tutorial-loop_and_import/main.mjs
+# define MAIN_JS_PATH C:/Users/22290/ScreepsArena/tutorial-loop_and_import/
 ```
 
 &nbsp;&nbsp;&nbsp;&nbsp;Run the ```build.py``` to transcrypt your python code to ```main.mjs``` code.

--- a/tutorials/tutorial10-Final test.md
+++ b/tutorials/tutorial10-Final test.md
@@ -11,7 +11,7 @@
 # define USE_SCORE_COLLECTOR 0
 
 # // Project Config
-# define MAIN_JS_PATH C:/Users/22290/ScreepsArena/tutorial-final_test/main.mjs
+# define MAIN_JS_PATH C:/Users/22290/ScreepsArena/tutorial-final_test/
 ```
 
 &nbsp;&nbsp;&nbsp;&nbsp;It's the last tutorial. So i'd like to teach you a advanced skill. But at here,i will provided a very simple code to solve it first:

--- a/tutorials/tutorial2-Simple move.md
+++ b/tutorials/tutorial2-Simple move.md
@@ -12,7 +12,7 @@
 # define USE_SCORE_COLLECTOR 0
 
 # // Project Config
-# define MAIN_JS_PATH C:/Users/22290/ScreepsArena/tutorial-simple_move/main.mjs
+# define MAIN_JS_PATH C:/Users/22290/ScreepsArena/tutorial-simple_move/
 ```
 
 &nbsp;&nbsp;&nbsp;&nbsp;Then we use ```get.creep() -> Creep``` ```get.flag() -> Flag``` and ```put.move(unit, to, options=None) -> int``` to reach out goal - ```make your creep go to the flag position```.

--- a/tutorials/tutorial3-First attack.md
+++ b/tutorials/tutorial3-First attack.md
@@ -11,7 +11,7 @@
 # define USE_SCORE_COLLECTOR 0
 
 # // Project Config
-# define MAIN_JS_PATH C:/Users/22290/ScreepsArena/tutorial-first_attack/main.mjs
+# define MAIN_JS_PATH C:/Users/22290/ScreepsArena/tutorial-first_attack/
 ```
 
 &nbsp;&nbsp;&nbsp;&nbsp;Then we use ```get.friend(st.creep) -> Creep``` ```get.enemy(st.creep) -> Creep``` and ```put.attack(unit, target, move=True) -> int``` to attack enemy creep.

--- a/tutorials/tutorial4-Creeps Bodies.md
+++ b/tutorials/tutorial4-Creeps Bodies.md
@@ -11,7 +11,7 @@
 # define USE_SCORE_COLLECTOR 0
 
 # // Project Config
-# define MAIN_JS_PATH C:/Users/22290/ScreepsArena/tutorial-creeps_bodies/main.mjs
+# define MAIN_JS_PATH C:/Users/22290/ScreepsArena/tutorial-creeps_bodies/
 ```
 
 &nbsp;&nbsp;&nbsp;&nbsp;The js tutorial tell us that diffrent ```body part``` make your creep have diffrent ability. And more same type body parts the creep has, the more effect of that body part the creep has.

--- a/tutorials/tutorial5-Store and transfer.md
+++ b/tutorials/tutorial5-Store and transfer.md
@@ -11,7 +11,7 @@
 # define USE_SCORE_COLLECTOR 0
 
 # // Project Config
-# define MAIN_JS_PATH C:/Users/22290/ScreepsArena/tutorial-store_and_transfer/main.mjs
+# define MAIN_JS_PATH C:/Users/22290/ScreepsArena/tutorial-store_and_transfer/
 ```
 
 &nbsp;&nbsp;&nbsp;&nbsp;Now i will write python code by sample js code:

--- a/tutorials/tutorial6-Terrain.md
+++ b/tutorials/tutorial6-Terrain.md
@@ -11,7 +11,7 @@
 # define USE_SCORE_COLLECTOR 0
 
 # // Project Config
-# define MAIN_JS_PATH C:/Users/22290/ScreepsArena/tutorial-terrain/main.mjs
+# define MAIN_JS_PATH C:/Users/22290/ScreepsArena/tutorial-terrain/
 ```
 
 &nbsp;&nbsp;&nbsp;&nbsp;Now i will write python code by sample js code:

--- a/tutorials/tutorial7-Spawn creeps.md
+++ b/tutorials/tutorial7-Spawn creeps.md
@@ -11,7 +11,7 @@
 # define USE_SCORE_COLLECTOR 0
 
 # // Project Config
-# define MAIN_JS_PATH C:/Users/22290/ScreepsArena/tutorial-spawn_creeps/main.mjs
+# define MAIN_JS_PATH C:/Users/22290/ScreepsArena/tutorial-spawn_creeps/
 ```
 
 &nbsp;&nbsp;&nbsp;&nbsp;Now i will write python code by sample js code:

--- a/tutorials/tutorial8-Harvest energy.md
+++ b/tutorials/tutorial8-Harvest energy.md
@@ -11,7 +11,7 @@
 # define USE_SCORE_COLLECTOR 0
 
 # // Project Config
-# define MAIN_JS_PATH C:/Users/22290/ScreepsArena/tutorial-harvest_energy/main.mjs
+# define MAIN_JS_PATH C:/Users/22290/ScreepsArena/tutorial-harvest_energy/
 ```
 
 &nbsp;&nbsp;&nbsp;&nbsp;Now i will write python code by sample js code:

--- a/tutorials/tutorial9-Construction.md
+++ b/tutorials/tutorial9-Construction.md
@@ -11,7 +11,7 @@
 # define USE_SCORE_COLLECTOR 0
 
 # // Project Config
-# define MAIN_JS_PATH C:/Users/22290/ScreepsArena/tutorial-construction/main.mjs
+# define MAIN_JS_PATH C:/Users/22290/ScreepsArena/tutorial-construction/
 ```
 
 &nbsp;&nbsp;&nbsp;&nbsp;Now i will write python code by sample js code:


### PR DESCRIPTION
According to my test result, if the path be like "[PATH]/main.mjs", program will find a folder called "main.mjs", except the file. Then, throw exception "Path does not exist". By fixing this problem, just remove "main.mjs" from your path string (like "[PATH]", except "[PATH]/main.mjs"). Then it will work properly.